### PR TITLE
Update keys.sh

### DIFF
--- a/docker/helpers/keys/keys.sh
+++ b/docker/helpers/keys/keys.sh
@@ -45,8 +45,8 @@ echo "dumping keys..."
 #   extract the useful bits of acme.json into teh `base64`
 #   binary to decode the b64 string into the pem format cert/key
 ##
-cat $CERT_JSON | jq -r $JQ_CRT | base64 -d > $CRT_FILE
-cat $CERT_JSON | jq -r $JQ_KEY | base64 -d > $KEY_FILE
+cat $CERT_JSON | jq -r '.Certificates[] | select(.Domain.Main=="my.domain.com") | .Certificate' | base64 -d > $CRT_FILE
+cat $CERT_JSON | jq -r '.Certificates[] | select(.Domain.Main=="my.domain.com") | .Key' | base64 -d > $KEY_FILE
 
 # 
 echo "done..."


### PR DESCRIPTION
I was having trouble with the keys.sh script, where it would dump all keys, even from my subdomains. This caused a problem with coredns, since it served the subdomain.example.com cert first, instead of example.com. I think this problem only occurs when your acme.json has other subdomain certs first, then the main one.